### PR TITLE
Modified the description of typical ratio of train and test dataset

### DIFF
--- a/src/DataProcessorModule.py
+++ b/src/DataProcessorModule.py
@@ -65,7 +65,8 @@ class DataProcessorModule:
 
     def train_test_split(self, processed_data, test_size=0.2):
         """
-        Splits the processed dataset first 20% into a training set and 80% into a testing set.
+        Splits the processed dataset into training and testing sets.
+        By default, 80% of the data is used for training, and 20% is used for testing.
         
         Returns:
             tuple: A tuple containing two lists:


### PR DESCRIPTION
## Summary

This PR addresses an issue in the train_test_split method of the DataProcessorModule, where the description of splitting the dataset did not reflect the intended 80% training and 20% testing ratio. The changes ensure that the description of processed data is split correctly and as expected.